### PR TITLE
Revert "Add coverage badge"

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -23,7 +23,8 @@ jobs:
     with:
       additional-r-cmd-check-params: --as-cran
   coverage:
-    name: Coverage 📔
+    if: github.event_name == 'pull_request'
+    name: Coverage 📔 
     uses: insightsengineering/r.pkg.template/.github/workflows/test-coverage.yaml@main
     secrets:
       REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,1 @@
 # SimulationEngineMSM
-
-<!-- start badges -->
-[![Code Coverage](https://raw.githubusercontent.com/insightsengineering/SimulationEngineMSM/_xml_coverage_reports/data/main/badge.svg)](https://raw.githubusercontent.com/insightsengineering/SimulationEngineMSM/_xml_coverage_reports/data/main/coverage.xml)
-<!-- end badges -->


### PR DESCRIPTION
Reverts insightsengineering/SimulationEngineMSM#33

SVG badges cannot be easily added to README because the repository is internal, and embedding badge in README requires access token.