### PR TITLE
Fix overflow error

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 
 -   `ExpSurvOS` now returns 0 instead of NaN for large values of t.
 -   `WeibSurvOS` now does not return an error for large values of t.
+-   `PWCSurvOS` now does not return an error for large values of t.
 -   `getSimulatedData` now also works when there are no transitions from progression to death, similarly for `getOneClinicalTrial` (which now warns if there are no such transitions at all).
 
 # simIDM 0.0.5

--- a/R/survivalFunctions.R
+++ b/R/survivalFunctions.R
@@ -196,11 +196,11 @@ PWCsurvPFS <- function(t, h01, h02, pw01, pw02) {
 #' @export
 #'
 #' @examples
-#' PwcOSInt(1:5, c(0.3, 0.5), c(0.5, 0.8), c(0.7, 1), c(0, 4), c(0, 8), c(0, 3))
-PwcOSInt <- function(x, h01, h02, h12, pw01, pw02, pw12) {
+#' PwcOSInt(1:5, 6, c(0.3, 0.5), c(0.5, 0.8), c(0.7, 1), c(0, 4), c(0, 8), c(0, 3))
+PwcOSInt <- function(x, t, h01, h02, h12, pw01, pw02, pw12) {
   PWCsurvPFS(x, h01, h02, pw01, pw02) *
     getPCWHazard(h01, pw01, x) *
-    exp(pwA(x, h12, pw12))
+    exp(pwA(x, h12, pw12) - pwA(t, h12, pw12))
 }
 
 #' OS Survival Function from Piecewise Constant Hazards
@@ -229,11 +229,18 @@ PWCsurvOS <- function(t, h01, h02, h12, pw01, pw02, pw12) {
   assert_intervals(pw12, length(h12))
 
   PWCsurvPFS(t, h01, h02, pw01, pw02) +
-    exp(-pwA(t, h12, pw12)) *
+    sapply(t, function(t) {
       integrateVector(PwcOSInt,
-        upper = t,
-        h01 = h01, h02 = h02, h12 = h12, pw01 = pw01, pw02 = pw02, pw12 = pw12
+                      upper = t,
+                      t = t,
+                      h01 = h01,
+                      h02 = h02,
+                      h12 = h12,
+                      pw01 = pw01,
+                      pw02 = pw02,
+                      pw12 = pw12
       )
+    })
 }
 
 #' Helper Function for Single Quantile for OS Survival Function

--- a/R/survivalFunctions.R
+++ b/R/survivalFunctions.R
@@ -231,14 +231,14 @@ PWCsurvOS <- function(t, h01, h02, h12, pw01, pw02, pw12) {
   PWCsurvPFS(t, h01, h02, pw01, pw02) +
     sapply(t, function(t) {
       integrateVector(PwcOSInt,
-                      upper = t,
-                      t = t,
-                      h01 = h01,
-                      h02 = h02,
-                      h12 = h12,
-                      pw01 = pw01,
-                      pw02 = pw02,
-                      pw12 = pw12
+        upper = t,
+        t = t,
+        h01 = h01,
+        h02 = h02,
+        h12 = h12,
+        pw01 = pw01,
+        pw02 = pw02,
+        pw12 = pw12
       )
     })
 }

--- a/man/PwcOSInt.Rd
+++ b/man/PwcOSInt.Rd
@@ -4,10 +4,12 @@
 \alias{PwcOSInt}
 \title{Helper Function of \code{PWCsurvOS()}}
 \usage{
-PwcOSInt(x, h01, h02, h12, pw01, pw02, pw12)
+PwcOSInt(x, t, h01, h02, h12, pw01, pw02, pw12)
 }
 \arguments{
 \item{x}{(\code{numeric})\cr  variable of integration.}
+
+\item{t}{(\code{numeric})\cr study time-points.}
 
 \item{h01}{(\verb{numeric vector})\cr constant transition hazards for 0 to 1 transition.}
 
@@ -29,5 +31,5 @@ the OS survival function for piecewise constant transition hazards, see  \code{P
 Helper Function of \code{PWCsurvOS()}
 }
 \examples{
-PwcOSInt(1:5, c(0.3, 0.5), c(0.5, 0.8), c(0.7, 1), c(0, 4), c(0, 8), c(0, 3))
+PwcOSInt(1:5, 6, c(0.3, 0.5), c(0.5, 0.8), c(0.7, 1), c(0, 4), c(0, 8), c(0, 3))
 }

--- a/tests/testthat/test-survivalFunctions.R
+++ b/tests/testthat/test-survivalFunctions.R
@@ -81,6 +81,12 @@ test_that("PWCsurvPFS works as expected", {
 test_that("PWCsurvOS works as expected", {
   actual <- PWCsurvOS(c(0, 1, 2, 1.4), c(0.7, 0.9), c(0.5, 1), c(0.9, 1.2), c(0, 4), c(0, 3), c(0, 7))
   expect_equal(actual, ExpSurvOS(c(0, 1, 2, 1.4), 0.7, 0.5, 0.9))
+
+  actual2 <- PWCsurvOS(100, 0.06, 1, 8, 0, 0, 0)
+  expect_equal(actual2, 0, tolerance = 1e-10)
+
+  actual3 <- PWCsurvOS(2000, c(0.7, 0.9), c(0.5, 1), c(0.9, 14), c(0, 4), c(0, 3), c(0, 7))
+  expect_equal(actual3, 0, tolerance = 1e-10)
 })
 
 # integrateVector ----

--- a/tests/testthat/test-survivalFunctions.R
+++ b/tests/testthat/test-survivalFunctions.R
@@ -89,6 +89,19 @@ test_that("PWCsurvOS works as expected", {
   expect_equal(actual3, 0, tolerance = 1e-10)
 })
 
+# PwcOSInt ----
+
+test_that("PwcOSInt works as expected", {
+  actual <- PwcOSInt(1, 1.1, c(0.3, 0.5), c(0.5, 0.8), c(0.7, 1), c(0, 4), c(0, 8), c(0, 3))
+  expect_equal(actual, 0.12568546, tolerance = 1e-6)
+
+  actual2 <- PwcOSInt(4, 4, c(0.3, 0.5), c(0.5, 0.8), c(0.7, 100), c(0, 2), c(0, 3), c(0, 3))
+  expect_equal(actual2, 0.010120956, tolerance = 1e-6)
+
+  actual3 <- PwcOSInt(700, 700, c(0.3, 0.5), c(0.5, 0.8), c(0.7, 100), c(0, 2), c(0, 3), c(0, 3))
+  expect_equal(actual3, 0, tolerance = 1e-6)
+})
+
 # integrateVector ----
 
 test_that("integrateVector works as expected", {


### PR DESCRIPTION
# Fix: Error in stats::integrate() : non-finite function value

The product in the formula for PWCSurvOS() is rearranged, moving the term `exp(- pwA(t, h12, pw12))` inside `PwcOSInt()`.

Fixes #60
