### PR TITLE
Add unit test and coverage reports to pkgdown documentation

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -23,7 +23,6 @@ jobs:
     with:
       additional-r-cmd-check-params: --as-cran
   coverage:
-    if: github.event_name != 'push'
     name: Coverage 📔
     uses: insightsengineering/r.pkg.template/.github/workflows/test-coverage.yaml@main
     secrets:

--- a/_pkgdown.yaml
+++ b/_pkgdown.yaml
@@ -8,8 +8,19 @@ template:
     ganalytics: UA-125641273-1
 
 navbar:
-  right:
-    - icon: fa-github
+  structure:
+    left: [intro, reference, articles, tutorials, news, reports]
+    right: [search, github]
+  components:
+    reports:
+      text: Reports
+      menu:
+        - text: Coverage report
+          href: coverage-report/
+        - text: Unit test report
+          href: unit-test-report/
+    github:
+      icon: fa-github
       href: https://github.com/insightsengineering/simIDM
 
 reference:


### PR DESCRIPTION
Modifies workflow and `pkgdown` configuration to add a drop-down with links to unit test report and coverage report.