### PR TITLE
Fix mistake in corPFSOS bootstrap

### DIFF
--- a/R/corPFSOS.R
+++ b/R/corPFSOS.R
@@ -286,11 +286,11 @@ corTrans <- function(transition) {
 #' @examples
 #' transition <- exponential_transition(h01 = 1.2, h02 = 1.5, h12 = 1.6)
 #' data <- getClinicalTrials(
-#'   nRep = 10, nPat = c(50), seed = 1234, datType = "1rowTransition",
+#'   nRep = 10, nPat = c(100), seed = 1234, datType = "1rowTransition",
 #'   transitionByArm = list(transition), dropout = list(rate = 0.5, time = 12),
 #'   accrual = list(param = "intensity", value = 7)
 #' )[[1]]
-#' corPFSOS(data, transition)
+#' corPFSOS(data, transition = exponential_transition())
 corPFSOS <- function(data, transition, bootstrap = TRUE, bootstrap_n = 100, bootstrap_level = 0.95) {
   assert_data_frame(data)
   assert_flag(bootstrap)
@@ -298,7 +298,7 @@ corPFSOS <- function(data, transition, bootstrap = TRUE, bootstrap_n = 100, boot
   assert_number(bootstrap_level, lower = 0.01, upper = 0.999)
 
   trans <- estimateParams(data, transition)
-  res <- list("corPFSOS" = corTrans(transition))
+  res <- list("corPFSOS" = corTrans(trans))
   if (bootstrap) {
     future::plan(future::multisession, workers = max(1, parallelly::availableCores() - 1))
     ids <- lapply(1:bootstrap_n, function(x) sample(seq_len(nrow(data)), nrow(data), replace = TRUE))
@@ -308,7 +308,6 @@ corPFSOS <- function(data, transition, bootstrap = TRUE, bootstrap_n = 100, boot
         packages = c("simIDM")
       )
       b_sample <- data[.x, , drop = FALSE]
-      prepared_data <- prepareData(b_sample)
       b_transition <- estimateParams(b_sample, transition)
       corTrans(b_transition)
     })

--- a/R/corPFSOS.R
+++ b/R/corPFSOS.R
@@ -286,7 +286,7 @@ corTrans <- function(transition) {
 #' @examples
 #' transition <- exponential_transition(h01 = 1.2, h02 = 1.5, h12 = 1.6)
 #' data <- getClinicalTrials(
-#'   nRep = 10, nPat = c(100), seed = 1234, datType = "1rowTransition",
+#'   nRep = 1, nPat = c(100), seed = 1234, datType = "1rowTransition",
 #'   transitionByArm = list(transition), dropout = list(rate = 0.5, time = 12),
 #'   accrual = list(param = "intensity", value = 7)
 #' )[[1]]

--- a/man/corPFSOS.Rd
+++ b/man/corPFSOS.Rd
@@ -34,9 +34,9 @@ Correlation of PFS and OS event times for data from the IDM
 \examples{
 transition <- exponential_transition(h01 = 1.2, h02 = 1.5, h12 = 1.6)
 data <- getClinicalTrials(
-  nRep = 10, nPat = c(50), seed = 1234, datType = "1rowTransition",
+  nRep = 10, nPat = c(100), seed = 1234, datType = "1rowTransition",
   transitionByArm = list(transition), dropout = list(rate = 0.5, time = 12),
   accrual = list(param = "intensity", value = 7)
 )[[1]]
-corPFSOS(data, transition)
+corPFSOS(data, transition = exponential_transition())
 }

--- a/man/corPFSOS.Rd
+++ b/man/corPFSOS.Rd
@@ -34,7 +34,7 @@ Correlation of PFS and OS event times for data from the IDM
 \examples{
 transition <- exponential_transition(h01 = 1.2, h02 = 1.5, h12 = 1.6)
 data <- getClinicalTrials(
-  nRep = 10, nPat = c(100), seed = 1234, datType = "1rowTransition",
+  nRep = 1, nPat = c(100), seed = 1234, datType = "1rowTransition",
   transitionByArm = list(transition), dropout = list(rate = 0.5, time = 12),
   accrual = list(param = "intensity", value = 7)
 )[[1]]

--- a/tests/testthat/test-corPFSOS.R
+++ b/tests/testthat/test-corPFSOS.R
@@ -8,5 +8,5 @@ test_that("corPFSOS returns correct central estimate", {
     accrual = list(param = "intensity", value = 7)
   )[[1]]
   actual <- corPFSOS(data, transition = exponential_transition(), bootstrap = FALSE)
-  expect_equal(actual[[1]], corTrans(transition = transition), tolerance = 1e-2)
+  expect_equal(actual[[1]], 0.5764501, tolerance = 1e-3)
 })

--- a/tests/testthat/test-corPFSOS.R
+++ b/tests/testthat/test-corPFSOS.R
@@ -1,0 +1,12 @@
+# corPFSOS ----
+
+test_that("corPFSOS returns correct central estimate", {
+  transition <- exponential_transition(h01 = 1.2, h02 = 1.5, h12 = 1.6)
+  data <- getClinicalTrials(
+    nRep = 1, nPat = c(20000), seed = 1234, datType = "1rowTransition",
+    transitionByArm = list(transition), dropout = list(rate = 0.5, time = 12),
+    accrual = list(param = "intensity", value = 7)
+  )[[1]]
+  actual <- corPFSOS(data, transition = exponential_transition(), bootstrap = FALSE)
+  expect_equal(actual[[1]], corTrans(transition = transition), tolerance = 1e-2)
+})


### PR DESCRIPTION
Fixes mistake I found in corPFSOS. We displayed `corTrans()` of initial `TransitionParameters`, need `corTrans()` of estimated object instead.
