### PR TITLE
Change default landing page for gh-pages

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -16,6 +16,6 @@ jobs:
     uses: insightsengineering/r.pkg.template/.github/workflows/pkgdown.yaml@main
     with:
       refs-order: c("latest-tag", "main")
-      default-landing-page: latest-tag
+      default-landing-page: main
     secrets:
       REPO_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ remotes::install_github("insightsengineering/simIDM")
 ## Getting Started
 
 See also the [quick
-start](https://insightsengineering.github.io/simIDM/latest-tag/articles/quickstart.html)
+start](https://insightsengineering.github.io/simIDM/main/articles/quickstart.html)
 vignette or get started by trying out this example:
 
 ``` r

--- a/README.rmd
+++ b/README.rmd
@@ -73,7 +73,7 @@ remotes::install_github("insightsengineering/simIDM")
 
 ## Getting Started
 
-See also the [quick start](https://insightsengineering.github.io/simIDM/latest-tag/articles/quickstart.html) vignette or get started by trying out this example:
+See also the [quick start](https://insightsengineering.github.io/simIDM/main/articles/quickstart.html) vignette or get started by trying out this example:
 
 ```{r getting-started, results = 'hide'}
 library(simIDM)


### PR DESCRIPTION
`latest-tag` does not exist yet, so changing it to `main`. When you have a new tag or release available, change this back to `latest-tag`.
